### PR TITLE
docs: homebrew installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ```diff
 ! Support development of this project > patreon.com/iximiuz
-``` 
+```
 
 With this tool you can:
 
@@ -32,6 +32,14 @@ GOARCH=amd64
 curl -Ls https://github.com/iximiuz/cdebug/releases/latest/download/cdebug_${GOOS}_${GOARCH}.tar.gz | tar xvz
 
 sudo mv cdebug /usr/local/bin
+```
+
+### Homebrew
+
+If you're a [Homebrew](https://brew.sh/) user, you can install the tool via brew on macOS or Linux:
+
+```sh
+$ brew install cdebug
 ```
 
 At the moment, the following systems are (kinda sorta) supported:


### PR DESCRIPTION
```
$ brew install cdebug
==> Fetching cdebug
==> Downloading https://ghcr.io/v2/homebrew/core/cdebug/manifests/0.0.7
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/cdebug/blobs/sha256:9087e51798a9cb24290ad4c353e8b0fd8ca224f092f780263996467b68655205
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:9087e51798a9cb24290ad4c353e8b0fd8ca224f092f780263996467b68655205?se=2023-01-18T16%3A5
######################################################################## 100.0%
==> Pouring cdebug--0.0.7.arm64_ventura.bottle.tar.gz
==> Caveats
Bash completion has been installed to:
  /opt/homebrew/etc/bash_completion.d
==> Summary
🍺  /opt/homebrew/Cellar/cdebug/0.0.7: 8 files, 18.3MB
```