### PR TITLE
symbolic link is unnecessary, since  they cannot be created in a read-only rootfs

### DIFF
--- a/cmd/exec/exec.go
+++ b/cmd/exec/exec.go
@@ -308,9 +308,7 @@ if [ ${CURRENT_NIX_INODE} -ne ${TARGET_NIX_INODE} ]; then
 fi
 {{ end }}
 
-ln -s /proc/${CURRENT_PID}/root/ /proc/{{ .TARGET_PID }}/root/.cdebug-{{ .ID }}
-
-export CDEBUG_ROOTFS=/.cdebug-{{ .ID }}
+export CDEBUG_ROOTFS=/proc/${CURRENT_PID}/root/
 
 cat > /.cdebug-entrypoint.sh <<EOF
 #!/bin/sh

--- a/cmd/exec/exec_kubernetes.go
+++ b/cmd/exec/exec_kubernetes.go
@@ -93,7 +93,7 @@ func runDebuggerKubernetes(ctx context.Context, cli cliutil.CLI, opts *options) 
 
 	cli.PrintAux("Starting debugger container...\n")
 
-	useChroot := isRootUser(opts.user) && !isReadOnlyRootFS(pod, targetName) && !runsAsNonRoot(pod, targetName)
+	useChroot := isRootUser(opts.user) && !runsAsNonRoot(pod, targetName)
 	if err := runPodDebugger(
 		ctx,
 		cli,


### PR DESCRIPTION
fix #43  #68  #70 