### PR TITLE
feat(oidc): support OIDC in kubeconfig

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -6,6 +6,7 @@ import (
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+		_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
 func GetRESTConfig(


### PR DESCRIPTION
`cdebug` fails if the kubeconfig uses an OIDC auth provider `No Auth Provider found for name "oidc"` (https://github.com/kubernetes/client-go/issues/345)

anonymously including `k8s.io/client-go/plugin/pkg/client/auth/oidc` does the trick:

```bash
cdebug exec -it -n probers-dev --kubeconfig kubeconfig pod/payments-mq-694fc56cc4-qj6j9 
```

