### PR TITLE
fix: support ssh:// DOCKER_HOST via connhelper

### DIFF
--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
+	"os"
 
+	"github.com/docker/cli/cli/connhelper"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
@@ -28,8 +31,28 @@ func NewClient(opts Options) (*Client, error) {
 		client.FromEnv,
 		client.WithAPIVersionNegotiation(),
 	}
-	if len(opts.Host) > 0 {
-		dockerOpts = append(dockerOpts, client.WithHost(opts.Host))
+
+	host := opts.Host
+	if host == "" {
+		host = os.Getenv("DOCKER_HOST")
+	}
+	if host != "" {
+		helper, err := connhelper.GetConnectionHelper(host)
+		if err != nil {
+			return nil, fmt.Errorf("cannot resolve Docker connection helper: %w", err)
+		}
+		if helper != nil {
+			httpClient := &http.Client{
+				Transport: &http.Transport{DialContext: helper.Dialer},
+			}
+			dockerOpts = append(dockerOpts,
+				client.WithHTTPClient(httpClient),
+				client.WithHost(helper.Host),
+				client.WithDialContext(helper.Dialer),
+			)
+		} else if opts.Host != "" {
+			dockerOpts = append(dockerOpts, client.WithHost(opts.Host))
+		}
 	}
 
 	inner, err := client.NewClientWithOpts(dockerOpts...)


### PR DESCRIPTION
DOCKER_HOST=ssh://... fails with:

    Get "http://user%!j(MISSING)host/v1.51/...": dial tcp: lookup user@host: no such host

cdebug isn't wiring up `connhelper`, so the docker SDK has no SSH dialer and falls back to a TCP dial against the literal `user@host`. (The `%!j(MISSING)` is a downstream fmt bug — `@` gets percent-encoded to `%40`, then the encoded URL is later used as a format string.)

This adds the connhelper handshake from docker/cli's `cli/command/cli.go`. `connhelper` is already in the module graph via `github.com/docker/cli`, no new deps.

Tested against a Docker Swarm — `cdebug exec` over `ssh://` now connects, negotiates the API, and injects the sidecar.